### PR TITLE
Fixed npm i failure on linux-based systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "homepage": "https://shadowproject.io/",
   "dependencies": {
     "socks5-https-client": "1.2.0",
-    "unzip": "0.1.11",
+    "unzip": "0.1.11"
+  },
+  "optionalDependencies": {
     "windows-shortcuts": "0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm install` was failing due to an attempted install of the **windows-shortcuts** module. Moved module to `optionalDependencies` object. Failure to install this object will not cause `npm install` failure.